### PR TITLE
runtime: update dependencies, changelog and bump version to v1.83.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,13 @@ jobs:
 
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          driver-opts: image=moby/buildkit:latest
+          buildkitd-flags: --debug
+          driver: docker-container
+          name: cr8s-builder
+          use: true
 
       # - name: 💾 Cache Docker layers
       #   uses: actions/cache@v4
@@ -42,7 +49,7 @@ jobs:
           docker buildx build \
             --file Dockerfile.dev \
             --tag ghcr.io/johnbasrai/cr8s/rust-dev:latest \
-            --tag ghcr.io/johnbasrai/cr8s/rust-dev:v1.83 \
+            --tag ghcr.io/johnbasrai/cr8s/rust-dev:v1.83.1 \
             --cache-from=type=gha \
             --cache-to=type=gha,mode=max \
             --push .
@@ -52,7 +59,7 @@ jobs:
           docker buildx build \
             --file Dockerfile.runtime \
             --tag ghcr.io/johnbasrai/cr8s/rust-runtime:latest \
-            --tag ghcr.io/johnbasrai/cr8s/rust-runtime:v0.3.0 \
+            --tag ghcr.io/johnbasrai/cr8s/rust-runtime:v0.3.1 \
             --cache-from=type=gha \
             --cache-to=type=gha,mode=max \
             --push .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v0.1.0] – 2025-05-08
+## [v1.83.1] – 2025-05-15
+
+### Added
+- Added `libssl3` and `libpq5` to runtime container for Rocket + Diesel support
+- Upgraded base image from `debian:bullseye-slim` to `debian:bookworm-slim`
+- Added `appuser` non-root user for secure runtime execution
+
+## [v1.83.0] – 2025-05-08
 
 ### Added
 - Initial release of `rust-dev` and `rust-runtime` containers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,3 +24,36 @@ For example:
 - `tooling-update-*` – new tools or infra additions
 
 These conventions help ensure traceability and clean semver alignment across container consumers.
+
+## 🐳 Updating Dockerfiles and Releasing New Container Versions
+
+If you change `Dockerfile.dev` or `Dockerfile.runtime`, follow these steps:
+
+1. **Choose a new version** using semantic versioning aligned with Rust:
+   - Use `vX.Y.Z` where `X.Y` tracks the Rust version (e.g. `1.83`)
+   - Bump `Z` for patch-level updates (e.g. adding packages like `libssl3`, updating the base image)
+   - For a full Rust version upgrade (e.g. `1.84`), start with `v1.84.0`
+   - You can find the current version in `.github/workflows/ci.yml`
+
+2. **Update the version tag** inside `.github/workflows/ci.yml`:
+   ```yaml
+   --tag ghcr.io/johnbasrai/cr8s/rust-runtime:v1.83.1
+   ```
+
+3. Commit your changes:
+
+> ```
+> git add Dockerfile.runtime
+> git commit -m "runtime: add <change summary> (v1.83.1)"
+> git tag v1.83.1
+> git push origin main --tags
+> ```
+
+4. CI will automatically build and push:
+
+- :v1.83.1 for reproducibility
+- :latest as the rolling tag
+
+✅ Keep commits clean and use changelogs if available.<br>
+✅ Don't edit CI unless you're changing how containers are built or tagged.
+

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,12 +1,21 @@
-# Use debian:bullseye-slim from about  May 1 2025
-FROM debian@sha256:fdd75562fdcde1039c2480a1ea1cd2cf03b18b6e4cb551cabb03bde66ade8a5d
+# Minimal runtime image for Rust Rocket/Diesel apps like cr8s
 
-# Optional runtime deps — include only what you know you need
+FROM debian:bookworm-slim
+
+# Install runtime libraries for Rocket, Diesel/Postgres, and TLS
 RUN apt-get update && apt-get install -y \
+    libssl3 \
+    libpq5 \
     ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
-# Downstream containers like cr8s will COPY the app binary and add their own layers
+# Set working directory for downstream use
+WORKDIR /app
 
-# Set default command (optional override)
-CMD ["/bin/bash"]
+# Create a non-root user for secure runtime
+RUN useradd -m appuser
+USER appuser
+
+# Downstream Dockerfiles will:
+# - COPY their binary to /app/
+# - Define ENTRYPOINT


### PR DESCRIPTION
- Added libssl3 and libpq5 to support Rocket and Diesel
- Upgraded base image to debian:bookworm-slim
- Added non-root appuser for secure runtime default
- Updated changelog, CI tags, and version to v1.83.1