### PR TITLE
ci: derive per-repo builder name and document usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,7 @@
-# Rust build output
-target/
+# Ignore everything by default
+*
 
-# VCS, editor cruft
-.git/
-*.swp
-*.rs.bk
-.DS_Store
-editorconfig
-gitattributes
+# Allow only files needed by Docker
+!Dockerfile.dev
+!Dockerfile.runtime
+!.github/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
 
       - name: 🧱 Create and Use Named Buildx Builder
         run: |
-          BUILDER_NAME=cr8s-builder
+          BUILDER_NAME="${BUILDER_NAME:-${GITHUB_REPOSITORY#*/}-builder}"
+          echo "BUILDER_NAME=$BUILDER_NAME" >> $GITHUB_ENV
           docker buildx inspect "$BUILDER_NAME" > /dev/null 2>&1 || \
             docker buildx create --name "$BUILDER_NAME" --driver docker-container --use
           docker buildx use "$BUILDER_NAME"
@@ -56,7 +57,7 @@ jobs:
       - name: 🛠️ Build and Push rust-dev
         run: |
           docker buildx build \
-            --builder cr8s-builder \
+            --builder ${{ env.BUILDER_NAME }} \
             --file Dockerfile.dev \
             --tag ghcr.io/johnbasrai/cr8s/rust-dev:${{ env.RUST_DEV_VERSION }} \
             --push \
@@ -68,10 +69,10 @@ jobs:
       - name: 📦 Build and Push rust-runtime
         run: |
           docker buildx build \
-            --builder cr8s-builder \
+            --builder ${{ env.BUILDER_NAME }} \
             --file Dockerfile.runtime \
             --tag ghcr.io/johnbasrai/cr8s/rust-runtime:${{ env.RUST_RUNTIME_VERSION }} \
-            --push 
+            --push \
             --cache-from type=local,src=/tmp/.buildx-cache \
             --cache-to type=local,dest=/tmp/.buildx-cache \
             .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,14 @@ jobs:
       - name: ⬇️ Checkout Code
         uses: actions/checkout@v4
 
-      - name: 🐳 Set up Docker Buildx
+      - name: 🐳 Set up Docker Buildx (Container Driver)
         uses: docker/setup-buildx-action@v3
         with:
           install: true
-          driver-opts: image=moby/buildkit:latest
-          buildkitd-flags: --debug
           driver: docker-container
           use: true
+          driver-opts: image=moby/buildkit:latest
+          buildkitd-flags: --debug
 
       - name: 🧱 Create and Use Named Buildx Builder
         run: |
@@ -45,7 +45,6 @@ jobs:
           docker buildx inspect "$BUILDER_NAME" > /dev/null 2>&1 || \
             docker buildx create --name "$BUILDER_NAME" --driver docker-container --use
           docker buildx use "$BUILDER_NAME"
-
 
       - name: 🔑 Login to GHCR
         uses: docker/login-action@v3
@@ -61,10 +60,10 @@ jobs:
             --file Dockerfile.dev \
             --tag ghcr.io/johnbasrai/cr8s/rust-dev:${{ env.RUST_DEV_VERSION }} \
             --push \
-            --cache-from type=local,src=/tmp/.buildx-cache \
-            --cache-to type=local,dest=/tmp/.buildx-cache \
+            --progress=plain \
+            --cache-from type=gha \
+            --cache-to type=gha \
             .
-
 
       - name: 📦 Build and Push rust-runtime
         run: |
@@ -73,6 +72,7 @@ jobs:
             --file Dockerfile.runtime \
             --tag ghcr.io/johnbasrai/cr8s/rust-runtime:${{ env.RUST_RUNTIME_VERSION }} \
             --push \
-            --cache-from type=local,src=/tmp/.buildx-cache \
-            --cache-to type=local,dest=/tmp/.buildx-cache \
+            --progress=plain \
+            --cache-from type=gha \
+            --cache-to type=gha \
             .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
           use: true
           buildkitd-flags: --debug
           driver-opts: image=moby/buildkit:latest
+          cache-to: type=gha
+          cache-from: type=gha
 
       - name: Get sha256sum of repo.
         run: tar cf - . | sha256sum
@@ -49,6 +51,7 @@ jobs:
 
       - name: 📦 Build and Push rust-runtime
         run: |
+          env | grep -i gha
           docker buildx build \
             --file Dockerfile.runtime \
             --tag ghcr.io/johnbasrai/cr8s/rust-runtime:${{ env.RUST_RUNTIME_VERSION }} \
@@ -60,6 +63,7 @@ jobs:
 
       - name: 🛠️ Build and Push rust-dev
         run: |
+          env | grep -i gha
           docker buildx build \
             --file Dockerfile.dev \
             --tag ghcr.io/johnbasrai/cr8s/rust-dev:${{ env.RUST_DEV_VERSION }} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,22 +29,16 @@ jobs:
       - name: ⬇️ Checkout Code
         uses: actions/checkout@v4
 
-      - name: 🐳 Set up Docker Buildx (Container Driver)
+      - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          install: true
           driver: docker-container
           use: true
-          driver-opts: image=moby/buildkit:latest
           buildkitd-flags: --debug
+          driver-opts: image=moby/buildkit:latest
 
-      - name: 🧱 Create and Use Named Buildx Builder
-        run: |
-          BUILDER_NAME="${BUILDER_NAME:-${GITHUB_REPOSITORY#*/}-builder}"
-          echo "BUILDER_NAME=$BUILDER_NAME" >> $GITHUB_ENV
-          docker buildx inspect "$BUILDER_NAME" > /dev/null 2>&1 || \
-            docker buildx create --name "$BUILDER_NAME" --driver docker-container --use
-          docker buildx use "$BUILDER_NAME"
+      - name: Get sha256sum of repo.
+        run: tar cf - . | sha256sum
 
       - name: 🔑 Login to GHCR
         uses: docker/login-action@v3
@@ -53,24 +47,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 🛠️ Build and Push rust-dev
+      - name: 📦 Build and Push rust-runtime
         run: |
           docker buildx build \
-            --builder ${{ env.BUILDER_NAME }} \
-            --file Dockerfile.dev \
-            --tag ghcr.io/johnbasrai/cr8s/rust-dev:${{ env.RUST_DEV_VERSION }} \
+            --file Dockerfile.runtime \
+            --tag ghcr.io/johnbasrai/cr8s/rust-runtime:${{ env.RUST_RUNTIME_VERSION }} \
             --push \
             --progress=plain \
             --cache-from type=gha \
             --cache-to type=gha \
             .
 
-      - name: 📦 Build and Push rust-runtime
+      - name: 🛠️ Build and Push rust-dev
         run: |
           docker buildx build \
-            --builder ${{ env.BUILDER_NAME }} \
-            --file Dockerfile.runtime \
-            --tag ghcr.io/johnbasrai/cr8s/rust-runtime:${{ env.RUST_RUNTIME_VERSION }} \
+            --file Dockerfile.dev \
+            --tag ghcr.io/johnbasrai/cr8s/rust-dev:${{ env.RUST_DEV_VERSION }} \
             --push \
             --progress=plain \
             --cache-from type=gha \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v1.83.0-rev4] – 2025-05-19
+## [2025.05.20]
+
+### Changed
+- 🐳 Switched Docker Buildx caching from `type=local` to `type=gha`
+- 🧱 Updated Buildx setup to use `docker-container` driver for full BuildKit support
+- 🐞 Enabled `--progress=plain` and `--debug` for better cache visibility
+- 🚀 CI now supports persistent layer caching across GitHub-hosted runners
+
+## [2025.05.19]
 
 ### Fixed
 - 🛠️ `chown /usr/local/cargo` so `dev` user can run cargo tools (`clippy`, `audit`, etc.)
@@ -15,14 +23,14 @@ All notable changes to this project will be documented in this file.
 - 🧾 Documented how Docker tags are defined and how to trace which commit built an image
 - 🔐 Added guidance on the `dev` user and permission requirements for `cargo` tooling
 
-## [v1.83.0-rev3] – 2025-05-15
+## [2025-05.15]
 
 ### Added
 - Added `libssl3` and `libpq5` to runtime container for Rocket + Diesel support
 - Upgraded base image from `debian:bullseye-slim` to `debian:bookworm-slim`
 - Added `appuser` non-root user for secure runtime execution
 
-## [v1.83.0] – 2025-05-08
+## [2025-05-08]
 
 ### Added
 - Initial release of `rust-dev` and `rust-runtime` containers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,55 +1,72 @@
-# Contributing to rust-base-containers
+# Contributing to `rust-base-containers`
 
-This repository builds and maintains the `rust-dev` and `rust-runtime` containers used by downstream projects like [`cr8s`](https://github.com/JohnBasrai/cr8s) and `cr8s-fe`. To maintain consistency across the ecosystem, we follow a structured versioning and tagging policy.
+This repository builds and maintains two container images:
 
----
+- `rust-dev`: a full-featured development container with Rust, tooling, and system dependencies
+- `rust-runtime`: a minimal runtime container for statically linked Rust binaries
 
-## 📦 1 Image Versioning
-
-We publish two container images:
-
-| Image         | Purpose                          | Versioning Source                      |
-|---------------|----------------------------------|----------------------------------------|
-| `rust-dev`    | Dev container with Rust + tools  | Rust toolchain version + repo revision |
-| `rust-runtime`| Minimal runtime container        | Matches downstream crate version       |
+These containers are consumed by downstream projects like [`cr8s`](https://github.com/JohnBasrai/cr8s) and `cr8s-fe`. This document defines the tagging strategy, versioning policy, and CI best practices for contributing to this repository.
 
 ---
 
-> ### 1.1 `rust-dev` Version Format
+## 📦 Versioning and Tagging Strategy
 
-- Format: `X.Y.0-revN` (e.g., `1.83.0-rev3`)
-- `X.Y.0`: Matches the Rust toolchain version (e.g. `1.83.0`)
-- `revN`: Tracks repo-level revisions, e.g.:
-  - Adding new tooling (e.g., `cargo-deny`, `wasm-bindgen`)
-  - Base OS or dependency updates
+This repository publishes two container images:
 
-> Example: `rust-dev:1.83.0-rev3`
+| Target        | Tag Format                | Purpose                                           |
+|---------------|---------------------------|---------------------------------------------------|
+| `rust-dev`    | `1.83.0-revN`             | Tracks Rust toolchain version + dev tooling state |
+| `rust-runtime`| `YYYY.MM.DD[.rN]`         | Tracks this repo's runtime container revisions     |
+
+### `rust-dev` Tag Format
+
+- Mirrors the current Rust toolchain version (`1.83.0`, `1.74.1`, etc.)
+- Uses a `-revN` suffix to track internal updates:
+  - New tooling (`cargo-audit`, `trunk`) or updated to them
+  - Base image changes
+  - CI enhancements
+- Examples:
+  - `1.83.0-rev1`
+  - `1.83.0-rev2`
+
+### `rust-runtime` Tag Format
+
+- Follows a **monotonically increasing**, **date-based format**:
+  - `YYYY.MM.DD` for the first release on a given day
+  - `YYYY.MM.DD.r2`, `YYYY.MM.DD.r3`, etc. for subsequent releases on same day
+- This format is:
+  - **Easy to understand**
+  - **Encodes recency**
+  - **Independent from downstream app versioning**
+- Examples:
+  - `2025.05.19`
+  - `2025.05.19.r2`
+
+> ⚠️ `rust-runtime` versions are fully decoupled from downstream `cr8s` or `cr8s-fe` crate versions.
+> This avoids confusion and lets container updates proceed independently.
+
+### Git Repository Tags
+
+- This repo uses the same `YYYY.MM.DD[.rN]` format for Git tags to reflect project-wide releases
+- These Git tags are used to:
+  - Track CI changes
+  - Anchor `CHANGELOG.md` updates
+  - Group container image releases under a single semantic checkpoint
 
 ---
 
-> ### 1.2 `rust-runtime` Version Format
+### 📌 Optional Addition to `CONTRIBUTING.md`
 
-- Format: matches the crate version of the downstream app (e.g., `cr8s`, `cr8s-fe`)
-- No `v` prefix
-- Derived from `Cargo.toml`
+You can add a one-liner under your changelog guidance:
 
-> Example: `rust-runtime:0.1.3` for `cr8s-fe@0.1.3`
+> 🔖 Each changelog section is titled with the Git tag:
+> `## [YYYY.MM.DD]` — the date **is the tag**, no additional date suffix is needed.
 
-### 📍 Where Docker Tags Are Defined
+---
 
-The `rust-dev` and `rust-runtime` image tags are **set explicitly** in the `ci.yml` workflow file:
+## 🧱 Buildx: Per-Repo Builders
 
-```yaml
-env:
-  RUST_DEV_VERSION:     1.83.0-rev3
-  RUST_RUNTIME_VERSION: 0.1.3
-```
-
-### 🧱 Named Buildx Builder per Repo
-
-To avoid cache collisions between repositories using Docker Buildx, CI workflows should use a **repo-specific builder name**. This is especially important when enabling layer caching with `--cache-from` and `--cache-to`.
-
-Recommended pattern in `ci.yml`:
+To avoid Docker layer cache collisions, each repository uses a **dedicated Buildx builder**:
 
 ```yaml
 - name: 🧱 Create and Use Named Buildx Builder
@@ -61,7 +78,8 @@ Recommended pattern in `ci.yml`:
     docker buildx use "$BUILDER_NAME"
 ```
 
-Later steps reference the builder like this:
+Later steps (e.g. image builds) reference the builder using the exported variable:
+Later steps (e.g. image builds) reference the builder using the exported variable:
 
 ```yaml
 --builder ${{ env.BUILDER_NAME }}
@@ -70,49 +88,3 @@ Later steps reference the builder like this:
 This ensures that each repository's CI jobs use isolated builder names, reducing cache contamination and improving reproducibility.
 
 ---
-
-### 🔐 Dev User and Cargo Permissions
-
-The `rust-dev` container runs as a non-root user named `dev` (`UID=1000`) for compatibility with host bind mounts and to support container-safe linting and formatting.
-
-To ensure tools like `cargo clippy`, `cargo audit`, and `cargo fmt` work correctly inside the container:
-
-```dockerfile
-# Dockerfile.dev
-RUN chown -R dev:dev /usr/local/cargo
-```
-
-This grants the `dev` user full access to the Rust toolchain, registry, and cache directories, which are typically owned by the user in standard setups (`$HOME/.cargo`).
-
-> ⚠️ Omitting this step may result in `Permission denied` errors when running cargo tools inside the container.
-
----
-
-## 2 🏷️ Tag Naming Rules
-
-- ❌ **No `v` prefix** in Docker image tags
-- ✅ Use `-revN` suffix for internal revisions (only applies to `rust-dev`)
-- ✅ Git tags for this repo may still use `v` (e.g., `v0.1.4` release)
-
----
-
-## 3 🌿 Branching and Releases
-
-- Branch names should reflect scope:  
-  `fix/image-tag-policy-alignment`, `ci/version-tagging`, etc.
-- Releases should correspond to meaningful changes (e.g., base image realignment, CI updates)
-- GitHub Releases should document new image tags and any relevant policy updates
-- **Do not push images to GHCR manually.** All images must be published via the automated GitHub Actions workflow to ensure version integrity and policy compliance.
-
----
-
-## 4 ✅ Examples
-
-| Git Tag     | Image                           | Tag                     |
-|-------------|----------------------------------|--------------------------|
-| `v0.1.4`    | `rust-runtime` (for cr8s-fe)     | `rust-runtime:0.1.3`     |
-| `v0.1.4`    | `rust-dev` with Rust 1.83.0      | `rust-dev:1.83.0-rev3`   |
-
----
-
-Thanks for helping maintain a consistent and clean container workflow! If you're contributing new image logic, please follow these policies or open a PR to propose changes.


### PR DESCRIPTION
- Dynamically generate buildx builder name using repo basename for isolation
- Export BUILDER_NAME via GITHUB_ENV for safe reuse across CI steps
- Prevents cache contamination across repos and improves portability
- Add documentation in CONTRIBUTING.md to explain per-repo builder naming and usage
- Fix minor syntax error in ci.yml file