### PR TITLE
fix(ci): remove manual builder and fix buildx line continuation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,6 @@ jobs:
           driver: docker-container
           use: true
 
-      - name: 🧱 Create and Use Named Buildx Builder
-        run: |
-          BUILDER_NAME=cr8s-builder
-          docker buildx inspect "$BUILDER_NAME" > /dev/null 2>&1 || \
-            docker buildx create --name "$BUILDER_NAME" --driver docker-container --use
-          docker buildx use "$BUILDER_NAME"
-
-
       - name: 🔑 Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -56,7 +48,6 @@ jobs:
       - name: 🛠️ Build and Push rust-dev
         run: |
           docker buildx build \
-            --builder cr8s-builder \
             --file Dockerfile.dev \
             --tag ghcr.io/johnbasrai/cr8s/rust-dev:${{ env.RUST_DEV_VERSION }} \
             --push \
@@ -64,14 +55,12 @@ jobs:
             --cache-to type=local,dest=/tmp/.buildx-cache \
             .
 
-
       - name: 📦 Build and Push rust-runtime
         run: |
           docker buildx build \
-            --builder cr8s-builder \
             --file Dockerfile.runtime \
             --tag ghcr.io/johnbasrai/cr8s/rust-runtime:${{ env.RUST_RUNTIME_VERSION }} \
-            --push 
+            --push \
             --cache-from type=local,src=/tmp/.buildx-cache \
             --cache-to type=local,dest=/tmp/.buildx-cache \
             .


### PR DESCRIPTION
- Removes legacy cr8s-builder block in favor of setup-buildx-action default builder
- Drops --builder flag from both build steps
- Fixes invalid line continuation after --push in rust-runtime step
- Ensures syntax correctness and consistent CI behavior

| Field      | Value             |
|------------|------------------|
| Status     | Fixed        |
| Type       | Fix               |
| Area       | CI                |
| Branch     | fix/ci-buildx     |
