### PR TITLE
Switch dev container from Diesel to SQLx CLI (1.83.0-rev6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       dev_version:
-        description: 'rust-dev version (e.g. 1.83.0-rev3)'
+        description: 'rust-dev version (e.g. 1.83.0-rev6)'
         required: true
       runtime_version:
         description: 'rust-runtime version (e.g. 0.1.3)'
@@ -19,7 +19,7 @@ permissions:
   packages: write
 
 env:
-  RUST_DEV_VERSION:     1.83.0-rev4
+  RUST_DEV_VERSION:     1.83.0-rev6
   RUST_RUNTIME_VERSION: 0.1.3
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+[unreleased]
+
+## [2025.06.10]
+
+### Changed
+- Bumped dev container version to 1.83.0-rev6
+
+### Added
+- Add motd warning that container has debugging tools and should not be used for production
+
 ## [2025.06.04]
 
 ### Changed
+- bump version to 1.80.0-rev5
 - 📝 Aligned changelog format with date-based git tags for consistency
 - 🐳 Enhanced runtime container with comprehensive debugging tools (curl, netcat, redis-tools, postgresql-client)
 - 📄 Updated documentation to reflect SQLx usage instead of Diesel

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -24,7 +24,7 @@ RUN rustup component add clippy rustfmt
 RUN rustup target add wasm32-unknown-unknown
 
 # Install cargo tools
-RUN cargo install diesel_cli --no-default-features --features postgres --locked && \
+RUN cargo install sqlx-cli --no-default-features --features postgres --locked && \
     cargo install cargo-audit --locked && \
     cargo install cargo-outdated --locked && \
     cargo install cargo-deny --version 0.17.0 --locked && \

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -26,12 +26,18 @@ RUN apt-get update && apt-get install -y \
     vim-tiny \
  && rm -rf /var/lib/apt/lists/*
 
+RUN echo '⚠️  WARNING: This container includes debugging tools for demo purposes.\n' \
+    '⚠️  Not intended for production use. Harden before deploying.\n' \
+    > /etc/motd
+
 # Set working directory for downstream use
 WORKDIR /app
 
 # Create a non-root user for secure runtime
 RUN useradd -m appuser
 USER appuser
+
+CMD ["sh", "-c", "cat /etc/motd && ./your-app"]
 
 # Downstream Dockerfiles will:
 # - COPY their binary to /app/

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ This project builds and publishes two containers under `ghcr.io/johnbasrai/cr8s/
 - Tagged as:  
   - `ghcr.io/johnbasrai/cr8s/rust-runtime:0.1.3`
 
+### ⚠️ Security Note:
+The rust-runtime container includes common debugging tools for development and demonstration purposes.
+Do not deploy this image to production without stripping these tools and applying hardening best practices.
+
 ---
 
 ## 🔁 Example: Using `rust-runtime` in cr8s


### PR DESCRIPTION

- Replace diesel_cli with sqlx-cli in Dockerfile.dev
- Update workflow to use 1.83-rev5 container version
- Maintains PostgreSQL-only feature set