### PR TITLE
docs: synchronize container versions and enhance runtime debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v1.83.0-rev4] – 2025-05-19
+## [2025.06.04]
+
+### Changed
+- 📝 Aligned changelog format with date-based git tags for consistency
+- 🐳 Enhanced runtime container with comprehensive debugging tools (curl, netcat, redis-tools, postgresql-client)
+- 📄 Updated documentation to reflect SQLx usage instead of Diesel
+
+### Added
+- 🔧 Network debugging tools for container connectivity troubleshooting
+- 🗄️ Database client tools for runtime debugging
+
+## [2025.05.20]
 
 ### Fixed
 - 🛠️ `chown /usr/local/cargo` so `dev` user can run cargo tools (`clippy`, `audit`, etc.)
@@ -15,14 +26,14 @@ All notable changes to this project will be documented in this file.
 - 🧾 Documented how Docker tags are defined and how to trace which commit built an image
 - 🔐 Added guidance on the `dev` user and permission requirements for `cargo` tooling
 
-## [v1.83.0-rev3] – 2025-05-15
+## [2025.05.15]
 
 ### Added
 - Added `libssl3` and `libpq5` to runtime container for Rocket + Diesel support
 - Upgraded base image from `debian:bullseye-slim` to `debian:bookworm-slim`
 - Added `appuser` non-root user for secure runtime execution
 
-## [v1.83.0] – 2025-05-08
+## [2025.05.08]
 
 ### Added
 - Initial release of `rust-dev` and `rust-runtime` containers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,10 +82,10 @@ This grants the `dev` user full access to the Rust toolchain, registry, and cach
 
 ## 4 ✅ Examples
 
-| Git Tag     | Image                           | Tag                     |
-|-------------|----------------------------------|--------------------------|
-| `v0.1.4`    | `rust-runtime` (for cr8s-fe)     | `rust-runtime:0.1.3`     |
-| `v0.1.4`    | `rust-dev` with Rust 1.83.0      | `rust-dev:1.83.0-rev3`   |
+| Git Tag      | Image                            | Tag                      |
+|------------- | -------------------------------- | -------------------------|
+| `2025.05.15` | `rust-runtime` (for cr8s-fe)     | `rust-runtime:0.1.3`     |
+| `2025.05.20` | `rust-dev` with Rust 1.83.0      | `rust-dev:1.83.0-rev5`   |
 
 ---
 

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,12 +1,29 @@
-# Minimal runtime image for Rust Rocket/Diesel apps like cr8s
-
+# Runtime image for Rust Rocket/SQLx apps like cr8s  
 FROM debian:bookworm-slim
 
-# Install runtime libraries for Rocket, Diesel/Postgres, and TLS
+# Install runtime libraries for Rocket, SQLx/Postgres, and TLS
+# Plus debugging tools for connectivity troubleshooting
 RUN apt-get update && apt-get install -y \
     libssl3 \
     libpq5 \
     ca-certificates \
+    # Network debugging tools
+    curl \
+    wget \
+    netcat-openbsd \
+    iputils-ping \
+    dnsutils \
+    # Process and system debugging
+    procps \
+    htop \
+    # Redis debugging
+    redis-tools \
+    # PostgreSQL debugging  
+    postgresql-client \
+    # Text processing for log analysis
+    grep \
+    less \
+    vim-tiny \
  && rm -rf /var/lib/apt/lists/*
 
 # Set working directory for downstream use

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Container tags follow a two-track policy:
 
-- `rust-dev` uses `X.Y.0-revN` format, where `X.Y` matches the Rust toolchain version (e.g., `1.83.0-rev3`)
+- `rust-dev` uses `X.Y.0-revN` format, where `X.Y` matches the Rust toolchain version (e.g., `1.83.0-rev5`)
 - `rust-runtime` uses `A.B.C` format aligned with downstream consumer crate versions (e.g., `0.1.3` from `cr8s-fe`)
 
 > ❗ Tags do **not** use a `v` prefix.  
@@ -57,7 +57,7 @@ This project builds and publishes two containers under `ghcr.io/johnbasrai/cr8s/
 
 ```Dockerfile
 # Dockerfile in cr8s/
-FROM ghcr.io/johnbasrai/cr8s/rust-runtime:v0.3.0
+FROM ghcr.io/johnbasrai/cr8s/rust-runtime:0.1.3
 
 # Copy your compiled binary
 COPY target/release/cr8s /usr/local/bin/cr8s


### PR DESCRIPTION
- Add comprehensive debugging tools to runtime container (curl, netcat, redis-tools, postgresql-client)
- Align changelog format with date-based git tags for consistency
- Update all documentation to reflect current container usage (rust-dev:1.83.0-rev5)
- Fix version examples and remove incorrect 'v' prefix from runtime tags
- Update comments to reflect SQLx usage instead of Diesel